### PR TITLE
Use relative protocol

### DIFF
--- a/includes/cls_ecshop.php
+++ b/includes/cls_ecshop.php
@@ -150,7 +150,7 @@ class ECS
      */
     function http()
     {
-        return (isset($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off')) ? 'https://' : 'http://';
+        return '//';
     }
 
     /**


### PR DESCRIPTION
If not, login to admin panel will be forbidden if running ECShop in HTTP behind a transparent HTTPS proxy.